### PR TITLE
V2: fix undefined this inside interactionConsume method

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -61,6 +61,7 @@ export class Client {
     this.project = project;
     this.collection = collection;
     this.endpoint = endpoint;
+    this.interactionConsume = this.interactionConsume.bind(this);
   }
 
   /**


### PR DESCRIPTION
## Why
When used in the react sdk, it pops up an error saying `cannot invoke "call" of undefined`

## What this PR does
- [x] Bind the method in the constructor

cc @benhinchley @sampotts for review