### PR TITLE
chore: run gh actions on a subset of release events.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,9 @@
 
 name: Push release to NPM
 
-on: release
+on:
+  release:
+    types: [published]
 
 jobs:
   publish:


### PR DESCRIPTION
GH action to publish releases to NPM are running 3 times instead of just once when a new release is created. This limits the actions that we run the action to just release:publish instead of running on all release events.