### PR TITLE
github: no need to run tests twice on publish

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           node-version: 10
       - run: npm install
-      # - run: npm test prepublish runs tests in this repo
+      # - no need to `run: npm test` as prepublish runs tests in this repo
       - uses: JS-DevTools/npm-publish@v1
         with:
           token: ${{ secrets.NPM_PUBLISH_TOKEN }}


### PR DESCRIPTION
github: no need to run tests twice on publish