### PR TITLE
feat: add SearchIOAnalytics as a simpler tracking solution

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1240,11 +1240,13 @@ export type TokenState = {
 
 export const POS_NEG_STORAGE_KEY = "sajari_tokens";
 // Just here to handle SSR execution (docs)
-const setItem = (key: string, value: string) => {
+export const setItem = (key: string, value: string) => {
   if (isSSR()) {
     return;
   }
-  return localStorage.setItem(key, value);
+  try {
+    localStorage.setItem(key, value);
+  } catch (_) {}
 };
 const getItem = (key: string): string | null => {
   if (isSSR()) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1247,7 +1247,9 @@ export const setItem = (key: string, value: string) => {
   }
   try {
     localStorage.setItem(key, value);
-  } catch (_) {}
+  } catch (_) {
+    console.error(`Search.io local storage "${key}" cannot be saved.`, value);
+  }
 };
 export const getItem = (key: string): string | null => {
   if (isSSR()) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import { USER_AGENT } from "./user-agent";
 import EventEmitter from "./events";
 import { isSSR } from "./ssr";
 export { EventEmitter };
+export { SearchIOAnalytics } from "./tracking";
 
 /**
  * NetworkError defines an error occuring from the network.
@@ -1248,7 +1249,7 @@ export const setItem = (key: string, value: string) => {
     localStorage.setItem(key, value);
   } catch (_) {}
 };
-const getItem = (key: string): string | null => {
+export const getItem = (key: string): string | null => {
   if (isSSR()) {
     return "";
   }

--- a/src/tracking.ts
+++ b/src/tracking.ts
@@ -15,6 +15,11 @@ interface EventState {
 type Value = string | number;
 type Identifier = "result_id" | "redirect_id" | "promotion_id";
 
+/**
+ * SearchIOAnalytics is a utility class for tracking and sending Search.io events.
+ * Event data is persisted to localStorage before being sent to track how users use
+ * search results and/or move through an ecommerce purchase funnel.
+ */
 export class SearchIOAnalytics {
   account: string;
   collection: string;
@@ -188,14 +193,24 @@ export class SearchIOAnalytics {
     }
   }
 
+  /**
+   * Update the current queryId
+   * @param queryId queryId that events calling track should be tracked against
+   */
   updateQueryID(queryId: string) {
     this.queryId = queryId;
   }
 
+  /**
+   * Track events against the current queryId
+   * @param type name of event to track (e.g. click, add_to_cart, purchase)
+   * @param value unique result identifier (e.g. product sku)
+   * @param metadata key/value pair of information relevant to the event
+   */
   track(type: string, value: Value, metadata?: Metadata) {
     let queryId = this.queryId;
     if (!FUNNEL_ENTRY_TYPES.includes(type)) {
-      const lastEvent = this.getEvents(value).reverse().pop();
+      const lastEvent = this.getEvents(value).pop();
 
       if (lastEvent) {
         queryId = lastEvent.queryId;
@@ -211,6 +226,13 @@ export class SearchIOAnalytics {
     this.trackForQuery(queryId, type, value, metadata);
   }
 
+  /**
+   * Track events against a specific current queryId
+   * @param queryId queryId that event should be tracked against
+   * @param type name of event to track (e.g. click, add_to_cart, purchase)
+   * @param value unique result identifier (e.g. product sku)
+   * @param metadata key/value pair of information relevant to the event
+   */
   trackForQuery(
     queryId: string,
     type: string,

--- a/src/tracking.ts
+++ b/src/tracking.ts
@@ -1,0 +1,222 @@
+import { getItem, RequestError, setItem } from ".";
+
+export const STORAGE_KEY = "searchio_events";
+const EXPIRY_DAYS = 30;
+const FUNNEL_ENTRY_TYPES = ["click"];
+
+type Metadata = Record<string, boolean | number | string>;
+interface EventState {
+  queryId: string;
+  type: string;
+  timestamp: number;
+  submitted: boolean;
+  metadata?: Metadata;
+}
+type Value = string | number;
+type Identifier = "result_id" | "redirect_id" | "promotion_id";
+
+export class SearchIOAnalytics {
+  account: string;
+  collection: string;
+  endpoint: string;
+  events: Record<Value, EventState[]>;
+  queryId?: string;
+
+  constructor(
+    account: string,
+    collection: string,
+    endpoint: string = "https://api.search.io"
+  ) {
+    this.account = account;
+    this.collection = collection;
+    this.endpoint = endpoint;
+    const storageContent = getItem(STORAGE_KEY);
+    try {
+      this.events = storageContent ? JSON.parse(storageContent) : {};
+    } catch (e) {
+      this.events = {};
+      console.error(
+        "Search.io event local storage key contains corrupt data.",
+        storageContent
+      );
+    }
+    this.flush().then(() => this.purge());
+  }
+
+  add(queryId: string, type: string, value: Value, metadata?: Metadata) {
+    const eventsForValue = this.getEvents(value);
+    eventsForValue.push({
+      queryId,
+      type,
+      metadata,
+      timestamp: Date.now(),
+      submitted: false,
+    });
+    this.setEvents(value, eventsForValue);
+    this.save();
+    this.flush();
+  }
+
+  save() {
+    setItem(STORAGE_KEY, JSON.stringify(this.events));
+  }
+
+  getIdentifierForType(type: string): Identifier {
+    switch (type) {
+      case "redirect":
+        return "redirect_id";
+      case "promotion_click":
+        return "promotion_id";
+      default:
+        return "result_id";
+    }
+  }
+
+  flush() {
+    const sends: Promise<void>[] = [];
+
+    Object.keys(this.events).forEach((value) => {
+      this.events[value].forEach(
+        ({ queryId, type, metadata, submitted }, i) => {
+          if (!submitted) {
+            sends.push(
+              this.sendEvent(queryId, type, {
+                [this.getIdentifierForType(type)]: value,
+                ...(metadata && { metadata }),
+              })
+                .then(() => {
+                  this.events[value][i].submitted = true;
+                  this.save();
+                })
+                .catch(() => {
+                  console.error(
+                    "Search.io event failed to send.",
+                    this.events[value][i]
+                  );
+                })
+            );
+          }
+        }
+      );
+    });
+
+    return Promise.all(sends).catch(() => {
+      // We already log fails above
+    });
+  }
+
+  async sendEvent(
+    queryId: string,
+    type: string,
+    data: Record<string, string | Metadata>
+  ): Promise<void> {
+    const response = await fetch(
+      `${this.endpoint}/v4/collections/${this.collection}:trackEvent`,
+      {
+        method: "POST",
+        headers: {
+          Accept: "application/json",
+          // XXX: This is to remove the need for the OPTIONS request
+          // https://stackoverflow.com/questions/29954037/why-is-an-options-request-sent-and-can-i-disable-it
+          "Content-Type": "text/plain",
+          "X-Account-Id": this.account,
+        },
+        body: JSON.stringify({
+          query_id: queryId,
+          type,
+          ...data,
+        }),
+      }
+    );
+
+    if (!response.ok) {
+      let message = response.statusText;
+      try {
+        let r = await response.json();
+        if (r.message) {
+          message = r.message;
+        }
+      } catch (_) {}
+
+      if (response.status === 403) {
+        throw new RequestError(
+          response.status,
+          "This domain is not authorized to make this request.",
+          new Error(message)
+        );
+      }
+
+      throw new RequestError(
+        response.status,
+        "Request failed due to a configuration error.",
+        new Error(message)
+      );
+    }
+
+    return response.json();
+  }
+
+  private getExpiry() {
+    return Date.now() - EXPIRY_DAYS * 24 * 60 * 60 * 1000;
+  }
+
+  purge() {
+    const expiry = this.getExpiry();
+    let requiresSave = false;
+
+    Object.keys(this.events).forEach((value) => {
+      const purged = this.events[value].filter(
+        ({ submitted, timestamp }) => !submitted || timestamp > expiry
+      );
+      if (purged.length < this.events[value].length) {
+        this.setEvents(value, purged);
+        requiresSave = true;
+      }
+    });
+    requiresSave && this.save();
+  }
+
+  getEvents(value: Value): EventState[] {
+    return (this.events[value] || []).slice();
+  }
+
+  setEvents(value: Value, events: EventState[]) {
+    if (events.length) {
+      this.events[value] = events;
+    } else {
+      delete this.events[value];
+    }
+  }
+
+  updateQueryID(queryId: string) {
+    this.queryId = queryId;
+  }
+
+  track(type: string, value: Value, metadata?: Metadata) {
+    let queryId = this.queryId;
+    if (!FUNNEL_ENTRY_TYPES.includes(type)) {
+      const lastEvent = this.getEvents(value).reverse().pop();
+
+      if (lastEvent) {
+        queryId = lastEvent.queryId;
+      }
+    }
+
+    if (!queryId) {
+      console.error(
+        "No queryId found. Use updateQueryID to set the current queryId or call trackForQuery with a specific queryId."
+      );
+      return;
+    }
+    this.trackForQuery(queryId, type, value, metadata);
+  }
+
+  trackForQuery(
+    queryId: string,
+    type: string,
+    value: Value,
+    metadata?: Metadata
+  ) {
+    this.add(queryId, type, value, metadata);
+  }
+}

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -8,6 +8,8 @@ import {
 } from "../src/index";
 
 const client = new Client("test", "test", "test.com");
+const setItemMock = jest.spyOn(Object.getPrototypeOf(localStorage), "setItem");
+const consoleErrorSpy = jest.spyOn(console, "error");
 
 describe("Client", () => {
   beforeEach(() => {
@@ -43,19 +45,24 @@ describe("Client", () => {
 });
 
 describe("setItem", () => {
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
   it("catches exceptions", () => {
-    const setItemMock = jest
-      .spyOn(Object.getPrototypeOf(localStorage), "setItem")
-      .mockImplementationOnce(() => {
-        throw new Error("pretend QuotaExceededError");
-      });
+    consoleErrorSpy.mockImplementation();
+    setItemMock.mockImplementationOnce(() => {
+      throw new Error("pretend QuotaExceededError");
+    });
 
     expect(() => {
       setItem("foo", "bar");
     }).not.toThrowError();
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      'Search.io local storage "foo" cannot be saved.',
+      "bar"
+    );
     expect(setItemMock).toHaveBeenCalled();
-
-    setItemMock.mockRestore();
   });
 });
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -4,6 +4,7 @@ import {
   DefaultSession,
   TrackingType,
   SearchResponseProto,
+  setItem,
 } from "../src/index";
 
 const client = new Client("test", "test", "test.com");
@@ -38,6 +39,23 @@ describe("Client", () => {
     };
 
     expect(create).toThrow(Error);
+  });
+});
+
+describe("setItem", () => {
+  it("catches exceptions", () => {
+    const setItemMock = jest
+      .spyOn(Object.getPrototypeOf(localStorage), "setItem")
+      .mockImplementationOnce(() => {
+        throw new Error("pretend QuotaExceededError");
+      });
+
+    expect(() => {
+      setItem("foo", "bar");
+    }).not.toThrowError();
+    expect(setItemMock).toHaveBeenCalled();
+
+    setItemMock.mockRestore();
   });
 });
 

--- a/test/tracking.test.ts
+++ b/test/tracking.test.ts
@@ -24,7 +24,7 @@ declare global {
 
 const setItemSpy = jest.spyOn(Object.getPrototypeOf(localStorage), "setItem");
 const sendEventSpy = jest.spyOn(SearchIOAnalytics.prototype, "sendEvent");
-const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation();
+const consoleErrorSpy = jest.spyOn(console, "error");
 const saveSpy = jest.spyOn(SearchIOAnalytics.prototype, "save");
 const flushSpy = jest.spyOn(SearchIOAnalytics.prototype, "flush");
 const addSpy = jest.spyOn(SearchIOAnalytics.prototype, "add");
@@ -413,14 +413,14 @@ describe("SearchIOAnalytics", () => {
         "test_collection"
       );
       analytics.events = {
-        sku1: [eventState],
+        sku1: [eventState, { ...eventState, queryId: "ghi789" }],
       };
 
       analytics.updateQueryID("def456");
       analytics.track("add_to_cart", "sku1");
 
       expect(trackForQuerySpy).toHaveBeenCalledWith(
-        "abc123",
+        "ghi789",
         "add_to_cart",
         "sku1",
         undefined
@@ -433,7 +433,7 @@ describe("SearchIOAnalytics", () => {
         "test_collection"
       );
       analytics.events = {
-        sku1: [eventState],
+        sku1: [eventState, { ...eventState, queryId: "ghi789" }],
       };
 
       analytics.updateQueryID("def456");

--- a/test/tracking.test.ts
+++ b/test/tracking.test.ts
@@ -1,0 +1,611 @@
+import { SearchIOAnalytics, STORAGE_KEY } from "../src/tracking";
+
+expect.extend({
+  toHaveBeenCalledBefore(spy1: jest.SpyInstance, spy2: jest.SpyInstance) {
+    const mostRecentInvocationOrder = (spy: jest.SpyInstance) =>
+      spy.mock.invocationCallOrder[
+        Object.keys(spy.mock.invocationCallOrder).length - 1
+      ];
+    return {
+      message: () =>
+        "expected first mock to have been called before second mock",
+      pass: mostRecentInvocationOrder(spy1) < mostRecentInvocationOrder(spy2),
+    };
+  },
+});
+
+declare global {
+  namespace jest {
+    interface Matchers<R> {
+      toHaveBeenCalledBefore(spy: jest.SpyInstance): R;
+    }
+  }
+}
+
+const setItemSpy = jest.spyOn(Object.getPrototypeOf(localStorage), "setItem");
+const sendEventSpy = jest.spyOn(SearchIOAnalytics.prototype, "sendEvent");
+const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation();
+const saveSpy = jest.spyOn(SearchIOAnalytics.prototype, "save");
+const flushSpy = jest.spyOn(SearchIOAnalytics.prototype, "flush");
+const addSpy = jest.spyOn(SearchIOAnalytics.prototype, "add");
+const trackForQuerySpy = jest.spyOn(
+  SearchIOAnalytics.prototype,
+  "trackForQuery"
+);
+const purgeSpy = jest.spyOn(SearchIOAnalytics.prototype, "purge");
+
+const eventState = {
+  queryId: "abc123",
+  type: "click",
+  timestamp: Date.now(),
+  submitted: true,
+};
+
+describe("SearchIOAnalytics", () => {
+  afterEach(() => {
+    fetchMock.resetMocks();
+    jest.clearAllMocks();
+    consoleErrorSpy.mockImplementation();
+    localStorage.removeItem(STORAGE_KEY);
+  });
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe("constructor", () => {
+    it("initialises events to an empty object if localStorage is null", () => {
+      const analytics = new SearchIOAnalytics(
+        "test_account",
+        "test_collection"
+      );
+
+      expect(analytics.events).toEqual({});
+    });
+
+    it("initialises events to an empty object if localStorage is corrupt", () => {
+      localStorage.setItem(STORAGE_KEY, "{foo");
+      const analytics = new SearchIOAnalytics(
+        "test_account",
+        "test_collection"
+      );
+
+      expect(analytics.events).toEqual({});
+      expect(consoleErrorSpy).toHaveBeenCalled();
+    });
+
+    it("initialises events to what is saved in localStorage", () => {
+      localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({
+          sku1: [eventState],
+        })
+      );
+      const analytics = new SearchIOAnalytics(
+        "test_account",
+        "test_collection"
+      );
+
+      expect(analytics.events).toEqual({
+        sku1: [eventState],
+      });
+    });
+
+    it("calls flush then purge", async () => {
+      const success = Promise.resolve([]);
+      flushSpy.mockReturnValueOnce(success);
+
+      new SearchIOAnalytics("test_account", "test_collection");
+
+      await success;
+
+      expect(flushSpy).toHaveBeenCalled();
+      expect(purgeSpy).toHaveBeenCalled();
+      expect(flushSpy).toHaveBeenCalledBefore(purgeSpy);
+    });
+  });
+
+  describe("sendEvent", () => {
+    it("formats the payload correctly", () => {
+      const analytics = new SearchIOAnalytics(
+        "test_account",
+        "test_collection"
+      );
+
+      fetchMock.mockResponseOnce("{}");
+
+      analytics.sendEvent("abc123", "click", {
+        result_id: "example_sku",
+        metadata: { sessionId: 123 },
+      });
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        "https://api.search.io/v4/collections/test_collection:trackEvent",
+        {
+          method: "POST",
+          headers: {
+            Accept: "application/json",
+            "Content-Type": "text/plain",
+            "X-Account-Id": "test_account",
+          },
+          body: JSON.stringify({
+            query_id: "abc123",
+            type: "click",
+            result_id: "example_sku",
+            metadata: { sessionId: 123 },
+          }),
+        }
+      );
+    });
+
+    it("uses a custom endpoint when supplied", () => {
+      const analytics = new SearchIOAnalytics(
+        "test_account",
+        "test_collection",
+        "https://test.com"
+      );
+
+      fetchMock.mockResponseOnce("{}");
+
+      analytics.sendEvent("abc123", "click", {
+        result_id: "example_sku",
+        metadata: { sessionId: 123 },
+      });
+
+      expect(fetchMock.mock.calls[0][0]).toEqual(
+        "https://test.com/v4/collections/test_collection:trackEvent"
+      );
+    });
+
+    it("handles messages in the status text", () => {
+      const analytics = new SearchIOAnalytics(
+        "test_account",
+        "test_collection"
+      );
+
+      fetchMock.mockResponseOnce("{}", {
+        status: 500,
+        statusText: "custom error",
+      });
+
+      expect.assertions(3);
+      return analytics
+        .sendEvent("abc123", "click", { result_id: "example_sku" })
+        .catch((err) => {
+          expect(err.statusCode).toEqual(500);
+          expect(err.message).toEqual(
+            "Request failed due to a configuration error."
+          );
+          expect(err.error.message).toEqual("custom error");
+        });
+    });
+
+    it("handles messages in the errors response", () => {
+      const analytics = new SearchIOAnalytics(
+        "test_account",
+        "test_collection"
+      );
+
+      fetchMock.mockResponseOnce('{ "message": "custom error" }', {
+        status: 500,
+      });
+
+      expect.assertions(3);
+      return analytics
+        .sendEvent("abc123", "click", { result_id: "example_sku" })
+        .catch((err) => {
+          expect(err.statusCode).toEqual(500);
+          expect(err.message).toEqual(
+            "Request failed due to a configuration error."
+          );
+          expect(err.error.message).toEqual("custom error");
+        });
+    });
+
+    it("handles 403s", () => {
+      const analytics = new SearchIOAnalytics(
+        "test_account",
+        "test_collection"
+      );
+
+      fetchMock.mockResponseOnce("", { status: 403, statusText: "Forbidden" });
+
+      expect.assertions(3);
+      return analytics
+        .sendEvent("abc123", "click", { result_id: "example_sku" })
+        .catch((err) => {
+          expect(err.statusCode).toEqual(403);
+          expect(err.message).toEqual(
+            "This domain is not authorized to make this request."
+          );
+          expect(err.error.message).toEqual("Forbidden");
+        });
+    });
+  });
+
+  describe("save", () => {
+    it("calls setItem with events", () => {
+      const analytics = new SearchIOAnalytics(
+        "test_account",
+        "test_collection"
+      );
+      analytics.events = {
+        sku1: [eventState],
+      };
+
+      analytics.save();
+
+      expect(setItemSpy).toHaveBeenCalledWith(
+        STORAGE_KEY,
+        JSON.stringify({
+          sku1: [eventState],
+        })
+      );
+    });
+  });
+
+  describe("updateQueryID", () => {
+    it("updates the current queryID", () => {
+      const analytics = new SearchIOAnalytics(
+        "test_account",
+        "test_collection"
+      );
+
+      expect(analytics.queryId).toBeUndefined();
+
+      analytics.updateQueryID("abc123");
+
+      expect(analytics.queryId).toEqual("abc123");
+    });
+  });
+
+  describe("setEvents", () => {
+    it("sets the events for a value", () => {
+      const analytics = new SearchIOAnalytics(
+        "test_account",
+        "test_collection"
+      );
+
+      analytics.setEvents("foo", [eventState]);
+
+      expect(analytics.events["foo"]).toEqual([eventState]);
+    });
+
+    it("deletes the value if events is empty", () => {
+      const analytics = new SearchIOAnalytics(
+        "test_account",
+        "test_collection"
+      );
+      analytics.events = {
+        foo: [eventState],
+      };
+
+      analytics.setEvents("foo", []);
+
+      expect(analytics.events).not.toHaveProperty("foo");
+    });
+  });
+
+  describe("getEvents", () => {
+    it("gets the events for a value", () => {
+      const analytics = new SearchIOAnalytics(
+        "test_account",
+        "test_collection"
+      );
+      analytics.events["foo"] = [eventState];
+
+      expect(analytics.getEvents("foo")).toEqual([eventState]);
+    });
+
+    it("gets an empty array if there are no events for a value", () => {
+      const analytics = new SearchIOAnalytics(
+        "test_account",
+        "test_collection"
+      );
+
+      expect(analytics.events).toEqual({});
+      expect(analytics.getEvents("foo")).toEqual([]);
+    });
+  });
+
+  describe("getIdentifierForType", () => {
+    const analytics = new SearchIOAnalytics("test_account", "test_collection");
+
+    it("returns 'redirect_id' for redirects", () => {
+      expect(analytics.getIdentifierForType("redirect")).toEqual("redirect_id");
+    });
+
+    it("returns 'promotion_id' for promotions", () => {
+      expect(analytics.getIdentifierForType("promotion_click")).toEqual(
+        "promotion_id"
+      );
+    });
+
+    it("returns 'result_id' for anything else", () => {
+      expect(analytics.getIdentifierForType("some other garbage")).toEqual(
+        "result_id"
+      );
+    });
+  });
+
+  describe("add", () => {
+    it("appends a new event for a value", () => {
+      const analytics = new SearchIOAnalytics(
+        "test_account",
+        "test_collection"
+      );
+      analytics.events["sku1"] = [eventState];
+
+      analytics.add("abc123", "add_to_cart", "sku1");
+
+      expect(analytics.events["sku1"]).toHaveLength(2);
+      expect(analytics.events["sku1"][1]).toMatchObject({
+        queryId: "abc123",
+        type: "add_to_cart",
+        submitted: false,
+      });
+    });
+
+    it("calls save then flush", () => {
+      const analytics = new SearchIOAnalytics(
+        "test_account",
+        "test_collection"
+      );
+
+      analytics.add("abc123", "add_to_cart", "sku1");
+
+      expect(saveSpy).toHaveBeenCalled();
+      expect(flushSpy).toHaveBeenCalled();
+      expect(saveSpy).toHaveBeenCalledBefore(flushSpy);
+    });
+  });
+
+  describe("trackForQuery", () => {
+    it("calls add", () => {
+      const analytics = new SearchIOAnalytics(
+        "test_account",
+        "test_collection"
+      );
+
+      analytics.trackForQuery("abc123", "add_to_cart", "sku1");
+
+      expect(addSpy).toHaveBeenCalledWith(
+        "abc123",
+        "add_to_cart",
+        "sku1",
+        undefined
+      );
+    });
+  });
+
+  describe("track", () => {
+    it("returns and logs an error if there is no current queryId", () => {
+      const analytics = new SearchIOAnalytics(
+        "test_account",
+        "test_collection"
+      );
+
+      analytics.track("add_to_cart", "sku1");
+
+      expect(consoleErrorSpy).toHaveBeenCalled();
+      expect(trackForQuerySpy).not.toHaveBeenCalled();
+    });
+
+    it("calls trackForQuery with current queryId", () => {
+      const analytics = new SearchIOAnalytics(
+        "test_account",
+        "test_collection"
+      );
+
+      analytics.updateQueryID("abc123");
+      analytics.track("add_to_cart", "sku1");
+
+      expect(trackForQuerySpy).toHaveBeenCalledWith(
+        "abc123",
+        "add_to_cart",
+        "sku1",
+        undefined
+      );
+    });
+
+    it("calls trackForQuery with queryId of previous event rather than current queryId", () => {
+      const analytics = new SearchIOAnalytics(
+        "test_account",
+        "test_collection"
+      );
+      analytics.events = {
+        sku1: [eventState],
+      };
+
+      analytics.updateQueryID("def456");
+      analytics.track("add_to_cart", "sku1");
+
+      expect(trackForQuerySpy).toHaveBeenCalledWith(
+        "abc123",
+        "add_to_cart",
+        "sku1",
+        undefined
+      );
+    });
+
+    it("calls trackForQuery with current queryId if type is click", () => {
+      const analytics = new SearchIOAnalytics(
+        "test_account",
+        "test_collection"
+      );
+      analytics.events = {
+        sku1: [eventState],
+      };
+
+      analytics.updateQueryID("def456");
+      analytics.track("click", "sku1");
+
+      expect(trackForQuerySpy).toHaveBeenCalledWith(
+        "def456",
+        "click",
+        "sku1",
+        undefined
+      );
+    });
+  });
+
+  describe("flush", () => {
+    it("calls sendEvent for all unsubmitted events", async () => {
+      const analytics = new SearchIOAnalytics(
+        "test_account",
+        "test_collection"
+      );
+      analytics.events = {
+        foo: [
+          eventState,
+          {
+            ...eventState,
+            type: "add_to_cart",
+            submitted: false,
+          },
+          {
+            ...eventState,
+            type: "purchase",
+            submitted: false,
+            metadata: {
+              discount: 0.2,
+              margin: 30.0,
+              customer_id: "12345",
+              ui_test_segment: "A",
+            },
+          },
+        ],
+        bar: [
+          {
+            ...eventState,
+            type: "redirect",
+            submitted: false,
+          },
+        ],
+      };
+
+      await analytics.flush();
+
+      expect(sendEventSpy).toHaveBeenCalledTimes(3);
+      expect(sendEventSpy).toHaveBeenCalledWith("abc123", "add_to_cart", {
+        result_id: "foo",
+      });
+      expect(sendEventSpy).toHaveBeenCalledWith("abc123", "purchase", {
+        result_id: "foo",
+        metadata: {
+          discount: 0.2,
+          margin: 30.0,
+          customer_id: "12345",
+          ui_test_segment: "A",
+        },
+      });
+      expect(sendEventSpy).toHaveBeenCalledWith("abc123", "redirect", {
+        redirect_id: "bar",
+      });
+    });
+
+    it("marks events as submitted if sendEvent succeeds and calls save", async () => {
+      const analytics = new SearchIOAnalytics(
+        "test_account",
+        "test_collection"
+      );
+      analytics.events["foo"] = [
+        { ...eventState, submitted: false },
+        { ...eventState, type: "add_to_cart", submitted: false },
+      ];
+
+      fetchMock.mockResponse("{}");
+
+      await analytics.flush();
+
+      expect(analytics.events.foo[0].submitted).toBe(true);
+      expect(analytics.events.foo[1].submitted).toBe(true);
+      expect(saveSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it("leaves events as not submitted if sendEvent fails and doesn't call save", async () => {
+      const analytics = new SearchIOAnalytics(
+        "test_account",
+        "test_collection"
+      );
+      analytics.events["foo"] = [{ ...eventState, submitted: false }];
+
+      sendEventSpy.mockRejectedValueOnce(new Error("didn't save"));
+
+      await analytics.flush();
+
+      expect(analytics.events.foo[0].submitted).toBe(false);
+      expect(saveSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("purge", () => {
+    function subtractDays(timestamp: number, days: number) {
+      return timestamp - days * 24 * 60 * 60 * 1000;
+    }
+
+    it("removes all submitted events older than 30 days and calls save", () => {
+      const nowMinus31Days = subtractDays(Date.now(), 31);
+      const nowMinus29Days = subtractDays(Date.now(), 29);
+      const analytics = new SearchIOAnalytics(
+        "test_account",
+        "test_collection"
+      );
+      analytics.events = {
+        foo: [
+          {
+            ...eventState,
+            timestamp: nowMinus31Days,
+          },
+          {
+            ...eventState,
+            type: "add_to_cart",
+            timestamp: nowMinus31Days,
+            submitted: false,
+          },
+          {
+            ...eventState,
+            type: "purchase",
+            timestamp: nowMinus29Days,
+          },
+        ],
+        bar: [
+          {
+            ...eventState,
+            type: "redirect",
+            timestamp: nowMinus31Days,
+          },
+        ],
+      };
+
+      analytics.purge();
+
+      expect(analytics.events).toEqual({
+        foo: [
+          {
+            ...eventState,
+            type: "add_to_cart",
+            timestamp: nowMinus31Days,
+            submitted: false,
+          },
+          {
+            ...eventState,
+            type: "purchase",
+            timestamp: nowMinus29Days,
+          },
+        ],
+      });
+      expect(saveSpy).toHaveBeenCalled();
+    });
+
+    it("doesn't call save when there is nothing to remove", () => {
+      const analytics = new SearchIOAnalytics(
+        "test_account",
+        "test_collection"
+      );
+
+      analytics.purge();
+
+      expect(saveSpy).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
After discussion with @benhinchley around the new/old API I opted to keep the tracking module entirely self-contained and not rely on the Client to handle communication with the API.