### PR TITLE
chore: use nvm in publish script

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,11 +10,12 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
-        with:
-          node-version: 10
-      - run: npm install
+      - uses: actions/checkout@v2
+      - name: Set the correct Node version using nvm
+        shell: bash -l {0}
+        run: nvm install
+      - name: Install dependencies
+        run: yarn install
       # - run: npm test prepublish runs tests in this repo
       - uses: JS-DevTools/npm-publish@v1
         with:

--- a/scripts/gen-useragent.js
+++ b/scripts/gen-useragent.js
@@ -23,7 +23,6 @@ if (scriptTag) {
 export const USER_AGENT = ["sajari-sdk-js/${pkg.version}", suffix]
   .filter(Boolean)
   .join(" ");
-
 `;
 
 fs.writeFileSync(path.join(__dirname, "../src/user-agent.ts"), template);


### PR DESCRIPTION
Also prevents user agent script from leaving repo in a dirty state after generation.