### PR TITLE
fix: return queryId from search response when it's supplied

### DIFF
--- a/src/tracking.ts
+++ b/src/tracking.ts
@@ -13,7 +13,7 @@ interface EventState {
   metadata?: Metadata;
 }
 type Value = string | number;
-type Identifier = "result_id" | "redirect_id" | "promotion_id";
+type Identifier = "result_id" | "redirect_id" | "banner_id";
 
 /**
  * SearchIOAnalytics is a utility class for tracking and sending Search.io events.
@@ -71,7 +71,7 @@ export class SearchIOAnalytics {
       case "redirect":
         return "redirect_id";
       case "promotion_click":
-        return "promotion_id";
+        return "banner_id";
       default:
         return "result_id";
     }
@@ -121,8 +121,6 @@ export class SearchIOAnalytics {
         method: "POST",
         headers: {
           Accept: "application/json",
-          // XXX: This is to remove the need for the OPTIONS request
-          // https://stackoverflow.com/questions/29954037/why-is-an-options-request-sent-and-can-i-disable-it
           "Content-Type": "text/plain",
           "Account-Id": this.account,
         },

--- a/src/tracking.ts
+++ b/src/tracking.ts
@@ -197,7 +197,7 @@ export class SearchIOAnalytics {
    * Update the current queryId
    * @param queryId queryId that events calling track should be tracked against
    */
-  updateQueryID(queryId: string) {
+  updateQueryId(queryId: string) {
     this.queryId = queryId;
   }
 
@@ -219,7 +219,7 @@ export class SearchIOAnalytics {
 
     if (!queryId) {
       console.error(
-        "No queryId found. Use updateQueryID to set the current queryId or call trackForQuery with a specific queryId."
+        "No queryId found. Use updateQueryId to set the current queryId or call trackForQuery with a specific queryId."
       );
       return;
     }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -569,13 +569,35 @@ describe("Pipeline", () => {
   });
 
   it("search request with simplified tracking", async () => {
-    fetchMock.mockResponseOnce(JSON.stringify({}));
+    const responseObj: SearchResponseProto = {
+      searchResponse: {
+        time: "0.003s",
+        totalResults: "0",
+        results: [],
+      },
+      banners: [],
+      queryId: "1f2d7ae0-fdd6-4eaf-85e9-cb5f3256e8c4",
+    };
+    fetchMock.mockResponseOnce(JSON.stringify(responseObj));
 
     const session = new DefaultSession(TrackingType.Event, "url");
-    await client
+    const [response, values] = await client
       .pipeline("test", "test")
       .search({ q: "hello" }, { ...session.next(), queryID: "test-query-id" });
 
+    expect(values).toEqual({});
+    expect(response).toStrictEqual({
+      time: 0.003,
+      totalResults: 0,
+      banners: [],
+      featureScoreWeight: 0,
+      results: [],
+      aggregates: {},
+      aggregateFilters: {},
+      activePromotions: [],
+      redirects: {},
+      queryId: "1f2d7ae0-fdd6-4eaf-85e9-cb5f3256e8c4",
+    });
     expect(fetchMock.mock.calls.length).toEqual(1);
     const firstCall = fetchMock.mock.calls[0];
     expect(firstCall[0]).toEqual(

--- a/test/tracking.test.ts
+++ b/test/tracking.test.ts
@@ -314,9 +314,9 @@ describe("SearchIOAnalytics", () => {
       expect(analytics.getIdentifierForType("redirect")).toEqual("redirect_id");
     });
 
-    it("returns 'promotion_id' for promotions", () => {
+    it("returns 'banner_id' for promotions", () => {
       expect(analytics.getIdentifierForType("promotion_click")).toEqual(
-        "promotion_id"
+        "banner_id"
       );
     });
 

--- a/test/tracking.test.ts
+++ b/test/tracking.test.ts
@@ -243,8 +243,8 @@ describe("SearchIOAnalytics", () => {
     });
   });
 
-  describe("updateQueryID", () => {
-    it("updates the current queryID", () => {
+  describe("updateQueryId", () => {
+    it("updates the current queryId", () => {
       const analytics = new SearchIOAnalytics(
         "test_account",
         "test_collection"
@@ -252,7 +252,7 @@ describe("SearchIOAnalytics", () => {
 
       expect(analytics.queryId).toBeUndefined();
 
-      analytics.updateQueryID("abc123");
+      analytics.updateQueryId("abc123");
 
       expect(analytics.queryId).toEqual("abc123");
     });
@@ -396,7 +396,7 @@ describe("SearchIOAnalytics", () => {
         "test_collection"
       );
 
-      analytics.updateQueryID("abc123");
+      analytics.updateQueryId("abc123");
       analytics.track("add_to_cart", "sku1");
 
       expect(trackForQuerySpy).toHaveBeenCalledWith(
@@ -416,7 +416,7 @@ describe("SearchIOAnalytics", () => {
         sku1: [eventState, { ...eventState, queryId: "ghi789" }],
       };
 
-      analytics.updateQueryID("def456");
+      analytics.updateQueryId("def456");
       analytics.track("add_to_cart", "sku1");
 
       expect(trackForQuerySpy).toHaveBeenCalledWith(
@@ -436,7 +436,7 @@ describe("SearchIOAnalytics", () => {
         sku1: [eventState, { ...eventState, queryId: "ghi789" }],
       };
 
-      analytics.updateQueryID("def456");
+      analytics.updateQueryId("def456");
       analytics.track("click", "sku1");
 
       expect(trackForQuerySpy).toHaveBeenCalledWith(


### PR DESCRIPTION
Forgot to return the `queryId` from the search response for the new Event tracking type.

I also refactored the `QueryPipeline.prototype.search` method, extracting most of the formatting logic out to their own functions to make it easier to scan and de-duped/simplified some logic in the process of doing that (e.g. the `aggregates` and `aggregateFilters` formatting was identical and copy/pasted).