### PR TITLE
fix: add redirect and promotion_click as funnel entry types

### DIFF
--- a/src/tracking.ts
+++ b/src/tracking.ts
@@ -2,7 +2,7 @@ import { getItem, RequestError, setItem } from ".";
 
 export const STORAGE_KEY = "searchio_events";
 const EXPIRY_DAYS = 30;
-const FUNNEL_ENTRY_TYPES = ["click"];
+const FUNNEL_ENTRY_TYPES = ["click", "redirect", "promotion_click"];
 
 type Metadata = Record<string, boolean | number | string>;
 interface EventState {

--- a/test/tracking.test.ts
+++ b/test/tracking.test.ts
@@ -427,25 +427,28 @@ describe("SearchIOAnalytics", () => {
       );
     });
 
-    it("calls trackForQuery with current queryId if type is click", () => {
-      const analytics = new SearchIOAnalytics(
-        "test_account",
-        "test_collection"
-      );
-      analytics.events = {
-        sku1: [eventState, { ...eventState, queryId: "ghi789" }],
-      };
+    it.each(["click", "redirect", "promotion_click"])(
+      "calls trackForQuery with current queryId if type is %s",
+      (type) => {
+        const analytics = new SearchIOAnalytics(
+          "test_account",
+          "test_collection"
+        );
+        analytics.events = {
+          sku1: [eventState, { ...eventState, queryId: "ghi789" }],
+        };
 
-      analytics.updateQueryId("def456");
-      analytics.track("click", "sku1");
+        analytics.updateQueryId("def456");
+        analytics.track(type, "sku1");
 
-      expect(trackForQuerySpy).toHaveBeenCalledWith(
-        "def456",
-        "click",
-        "sku1",
-        undefined
-      );
-    });
+        expect(trackForQuerySpy).toHaveBeenCalledWith(
+          "def456",
+          type,
+          "sku1",
+          undefined
+        );
+      }
+    );
   });
 
   describe("flush", () => {


### PR DESCRIPTION
Redirects and promotion clicks are always at the top of the funnel, so they should use the current `queryId` rather than any that may be cached.