### PR TITLE
fix: undefined activePins causes a fatal error

### DIFF
--- a/.changeset/famous-planes-thank.md
+++ b/.changeset/famous-planes-thank.md
@@ -1,0 +1,5 @@
+---
+"@sajari/sdk-js": patch
+---
+
+Fix undefined activePins causes a fatal error. This can happen if a promotion has no pins so the activePins will not appear in the response.

--- a/src/index.ts
+++ b/src/index.ts
@@ -426,7 +426,7 @@ function formatActivePins(
 ): Record<string, Set<string>> {
   const pins: Record<string, Set<string>> = {};
   activePromotions.forEach(({ activePins }) => {
-    activePins.forEach(({ key }) => {
+    activePins?.forEach(({ key }) => {
       if (!pins[key.field]) {
         pins[key.field] = new Set<string>();
       }
@@ -763,8 +763,8 @@ export interface PromotionExclusion {
  */
 export interface ActivePromotion {
   promotionId: string;
-  activePins: PromotionPin[];
-  activeExclusions: PromotionExclusion[];
+  activePins?: PromotionPin[];
+  activeExclusions?: PromotionExclusion[];
 }
 
 /**


### PR DESCRIPTION
Fix `undefined` activePins causes a fatal error. This can happen if a promotion has no pins so the `activePins` will not appear in the response.

![image](https://user-images.githubusercontent.com/12707960/169309808-2d2fd670-c2a2-4aca-a64e-c87a1693b557.png)

SF-830